### PR TITLE
adição de canal de origem ao plugin

### DIFF
--- a/admin/class-dito-admin.php
+++ b/admin/class-dito-admin.php
@@ -145,7 +145,8 @@ class Dito_Admin {
   public function dito_tracking_settings() {
     $this->dito_register_setting('dito_home_track_enabled', true);
     $this->dito_register_setting('dito_post_track_enabled', true);
-    $this->dito_register_setting('dito_page_track_enabled', true);
+		$this->dito_register_setting('dito_page_track_enabled', true);
+		$this->dito_register_setting('dito_track_canal_enabled', true);
   }
 
   public function dito_reset_settings() {
@@ -156,6 +157,7 @@ class Dito_Admin {
 		$this->delete_option('dito_news_name_selector');
 		$this->delete_option('dito_news_email_selector');
 		$this->delete_option('dito_news_btn_selector');
+		$this->delete_option('dito_track_canal_enabled');
 	}
 
 	public function dito_news_settings() {

--- a/admin/class-dito-admin.php
+++ b/admin/class-dito-admin.php
@@ -146,7 +146,7 @@ class Dito_Admin {
     $this->dito_register_setting('dito_home_track_enabled', true);
     $this->dito_register_setting('dito_post_track_enabled', true);
 		$this->dito_register_setting('dito_page_track_enabled', true);
-		$this->dito_register_setting('dito_track_canal_enabled', true);
+		$this->dito_register_setting('dito_origin');
   }
 
   public function dito_reset_settings() {
@@ -157,7 +157,7 @@ class Dito_Admin {
 		$this->delete_option('dito_news_name_selector');
 		$this->delete_option('dito_news_email_selector');
 		$this->delete_option('dito_news_btn_selector');
-		$this->delete_option('dito_track_canal_enabled');
+		$this->delete_option('dito_origin');
 	}
 
 	public function dito_news_settings() {

--- a/admin/partials/dito-admin-display.php
+++ b/admin/partials/dito-admin-display.php
@@ -77,7 +77,7 @@
               </td>
               <td>
                 <strong>Canal de origem:</strong>
-                <input type="text" name="dito_track_canal_enabled" <?php if($_REQUEST['dito_track_canal_enabled']) echo "checked" ?> />
+                <input type="text" name="dito_origin" value="<?php echo esc_attr( get_option('dito_origin') ); ?>" />
               </td>
             </tr>
           </table>

--- a/admin/partials/dito-admin-display.php
+++ b/admin/partials/dito-admin-display.php
@@ -75,6 +75,10 @@
                 <input type="checkbox" name="dito_page_track_enabled" <?php if(get_option('dito_page_track_enabled')) echo "checked" ?> value="true" />
                 <strong>Acessos as páginas</strong>
               </td>
+              <td>
+                <strong>Canal de origem:</strong>
+                <input type="text" name="dito_track_canal_enabled" <?php if($_POST['dito_track_canal_enabled']!='') echo "checked" ?> />
+              </td>
             </tr>
           </table>
         </div><!-- .dito-settings-box -->

--- a/admin/partials/dito-admin-display.php
+++ b/admin/partials/dito-admin-display.php
@@ -77,7 +77,7 @@
               </td>
               <td>
                 <strong>Canal de origem:</strong>
-                <input type="text" name="dito_track_canal_enabled" <?php if($_POST['dito_track_canal_enabled']!='') echo "checked" ?> />
+                <input type="text" name="dito_track_canal_enabled" <?php if($_REQUEST['dito_track_canal_enabled']) echo "checked" ?> />
               </td>
             </tr>
           </table>

--- a/public/partials/track/track-home-js.php
+++ b/public/partials/track/track-home-js.php
@@ -1,5 +1,6 @@
 <?php if(is_home() && get_option("dito_home_track_enabled")){ ?>
   dito.track({
-    action: 'acessou-home-blog'
+    action: 'acessou-home-blog',
+    origem: '<?php echo $_POST['dito_track_canal_enabled'] ?>'
   });
 <?php } ?>

--- a/public/partials/track/track-home-js.php
+++ b/public/partials/track/track-home-js.php
@@ -1,6 +1,8 @@
-<?php if(is_home() && get_option("dito_home_track_enabled")){ ?>
+<?php if(is_home()){ ?>
   dito.track({
     action: 'acessou-home-blog',
-    origem: '<?php echo $_REQUEST['dito_track_canal_enabled'] ?>'
+    data: {
+      origem: '<?php echo get_option('dito_origin') ?>'
+    }
   });
 <?php } ?>

--- a/public/partials/track/track-home-js.php
+++ b/public/partials/track/track-home-js.php
@@ -1,6 +1,6 @@
 <?php if(is_home() && get_option("dito_home_track_enabled")){ ?>
   dito.track({
     action: 'acessou-home-blog',
-    origem: '<?php echo $_POST['dito_track_canal_enabled'] ?>'
+    origem: '<?php echo $_REQUEST['dito_track_canal_enabled'] ?>'
   });
 <?php } ?>

--- a/public/partials/track/track-page-js.php
+++ b/public/partials/track/track-page-js.php
@@ -3,7 +3,7 @@
     action: 'acessou-pagina-blog',
     data: {
       pagina: '<?php echo get_the_title() ?>',
-      origem: '<?php echo $_POST['dito_track_canal_enabled'] ?>'
+      origem: '<?php echo $_REQUEST['dito_track_canal_enabled'] ?>'
     }
   });
 <?php } ?>

--- a/public/partials/track/track-page-js.php
+++ b/public/partials/track/track-page-js.php
@@ -3,9 +3,7 @@
     action: 'acessou-pagina-blog',
     data: {
       pagina: '<?php echo get_the_title() ?>',
-      data: {
-        origem: '<?php echo get_option('dito_origin') ?>'
-      }
+      origem: '<?php echo get_option('dito_origin') ?>'
     }
   });
 <?php } ?>

--- a/public/partials/track/track-page-js.php
+++ b/public/partials/track/track-page-js.php
@@ -3,7 +3,9 @@
     action: 'acessou-pagina-blog',
     data: {
       pagina: '<?php echo get_the_title() ?>',
-      origem: '<?php echo $_REQUEST['dito_track_canal_enabled'] ?>'
+      data: {
+        origem: '<?php echo get_option('dito_origin') ?>'
+      }
     }
   });
 <?php } ?>

--- a/public/partials/track/track-page-js.php
+++ b/public/partials/track/track-page-js.php
@@ -2,7 +2,8 @@
   dito.track({
     action: 'acessou-pagina-blog',
     data: {
-      pagina: '<?php echo get_the_title() ?>'
+      pagina: '<?php echo get_the_title() ?>',
+      origem: '<?php echo $_POST['dito_track_canal_enabled'] ?>'
     }
   });
 <?php } ?>

--- a/public/partials/track/track-post-js.php
+++ b/public/partials/track/track-post-js.php
@@ -12,7 +12,7 @@
       categorias: '<?php echo join(', ', $categories) ?>',
       author: '<?php echo get_the_author() ?>',
       data_publicacao: '<?php echo get_the_date('Y-m-d') ?>',
-      origem: '<?php echo $_REQUEST['dito_track_canal_enabled'] ?>'
+      origem: '<?php echo get_option('dito_origin') ?>'
     }
   });
 <?php } ?>

--- a/public/partials/track/track-post-js.php
+++ b/public/partials/track/track-post-js.php
@@ -12,6 +12,7 @@
       categorias: '<?php echo join(', ', $categories) ?>',
       author: '<?php echo get_the_author() ?>',
       data_publicacao: '<?php echo get_the_date('Y-m-d') ?>',
+      origem: '<?php echo $_POST['dito_track_canal_enabled'] ?>'
     }
   });
 <?php } ?>

--- a/public/partials/track/track-post-js.php
+++ b/public/partials/track/track-post-js.php
@@ -12,7 +12,7 @@
       categorias: '<?php echo join(', ', $categories) ?>',
       author: '<?php echo get_the_author() ?>',
       data_publicacao: '<?php echo get_the_date('Y-m-d') ?>',
-      origem: '<?php echo $_POST['dito_track_canal_enabled'] ?>'
+      origem: '<?php echo $_REQUEST['dito_track_canal_enabled'] ?>'
     }
   });
 <?php } ?>


### PR DESCRIPTION
## Adição de canal de origem

Fizemos a adição de um campo de texto chamado canal de origem, para que o administrador do plugin possa especificar de qual canal o track está vindo. 

Ex.: blog
